### PR TITLE
update dir glob to reflect the new dir structure

### DIFF
--- a/lib/i18n_country_translations/railtie.rb
+++ b/lib/i18n_country_translations/railtie.rb
@@ -6,7 +6,7 @@ module I18nCountryTranslations
       I18nCountryTranslations::Railtie.instance_eval do
         pattern = pattern_from app.config.i18n.available_locales
 
-        add("rails/locale/#{pattern}.yml")
+        add("rails/locale/**/#{pattern}.yml")
       end
     end
 


### PR DESCRIPTION
After upgrading to v1.1.0, the translation is broken due to the new directory structure.  Need to update the i18n dir pattern accordingly.
