### PR TITLE
Update glob to include locales again

### DIFF
--- a/i18n-country-translations.gemspec
+++ b/i18n-country-translations.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = "I18n Country Translations"
   s.description = "The purpose of this gem is to simply provide country translations. The gem is intended to be easy to combine with other gems that require i18n country translations so we can have common i18n country translation gem."
 
-  s.files        = Dir.glob("lib/**/*") + Dir.glob("rails/locale/*") +
+  s.files        = Dir.glob("lib/**/*") + Dir.glob("rails/locale/**/*") +
                    %w(README.rdoc MIT-LICENSE)
   s.test_files = Dir["test/**/*"]
   s.require_path = 'lib'


### PR DESCRIPTION
On current master the files in `rails/locale/`are not added to the gem. As result no translations are available.

```
$ gem build i18n-country-translations.gemspec
$ gem spec i18n-country-translations-1.1.1.gem
...
files:
- MIT-LICENSE
- README.rdoc
- lib/i18n-country-translations.rb
- lib/i18n_country_translations.rb
- lib/i18n_country_translations/railtie.rb
- lib/i18n_country_translations/version.rb
- lib/tasks/i18n-country-translations_tasks.rake
homepage: https://github.com/onomojo/i18n-country-translations
...
```

With the change:

```
$ gem build i18n-country-translations.gemspec
$ gem spec i18n-country-translations-1.1.1.gem
...
files:
- MIT-LICENSE
- README.rdoc
- lib/i18n-country-translations.rb
- lib/i18n_country_translations.rb
- lib/i18n_country_translations/railtie.rb
- lib/i18n_country_translations/version.rb
- lib/tasks/i18n-country-translations_tasks.rake
- rails/locale/iso_639-1/af.yml
- rails/locale/iso_639-1/ak.yml
- rails/locale/iso_639-1/am.yml
- rails/locale/iso_639-1/ar.yml
- rails/locale/iso_639-1/as.yml
- rails/locale/iso_639-1/az.yml
...
```
