### PR TITLE
Use full name for US in Hungarian locale

### DIFF
--- a/rails/locale/iso_639-1/hu.yml
+++ b/rails/locale/iso_639-1/hu.yml
@@ -242,7 +242,7 @@ hu:
     UA: Ukrajna
     UG: Uganda
     UM: Amerikai Csendes-óceáni Szigetek
-    US: Egyesült Államok
+    US: Amerikai Egyesült Államok
     UY: Uruguay
     UZ: Üzbegisztán
     VA: Vatikán


### PR DESCRIPTION
United States of America (the full name of the country) is "Amerikai Egyesült Államok". http://en.wikipedia.org/wiki/Names_of_the_United_States .
