### PR TITLE
support optional languages.

### DIFF
--- a/lib/i18n_country_translations/railtie.rb
+++ b/lib/i18n_country_translations/railtie.rb
@@ -1,10 +1,15 @@
 require 'rails'
+require "active_support"
 
 module I18nCountryTranslations
   class Railtie < ::Rails::Railtie #:nodoc:
+    config.i18n_countries_translations = ActiveSupport::OrderedOptions.new
+
     initializer 'i18n-country-translations' do |app|
       I18nCountryTranslations::Railtie.instance_eval do
-        pattern = pattern_from app.config.i18n.available_locales
+        locales = app.config.i18n_countries_translations.delete(:locales) ||
+          app.config.i18n.available_locales
+        pattern = pattern_from locales
 
         add("rails/locale/**/#{pattern}.yml")
       end


### PR DESCRIPTION
Hi

I added ability to specify loading locales. It can be useful in cases when I'm using not only available locales in my app. 

For example:
```ruby
require "i18n/backend/fallbacks"
I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
I18n.fallbacks.map(zh_CN: :zh)

config.i18n.available_locales = [:en, :zh_CN]
config.i18n_countries_translations.locales = [:en, :zh]  # <-- new option
```
and I can still use your gem to provide countries names from zh locale inspite of I haven't :zh locale in my i18n.
```ruby
I18n.t(:US, scope: :countries, locale: :zh_CN) # => "美国"
I18n.t(:US, scope: :countries, locale: :zh)  # => I18n::InvalidLocale: :zh is not a valid locale
```