### PR TITLE
Load all default fallbacks for a specific locale, by including all prefix subpatterns

### DIFF
--- a/lib/i18n_country_translations.rb
+++ b/lib/i18n_country_translations.rb
@@ -1,3 +1,4 @@
+require 'i18n_country_translations/locale_files_pattern_generator'
 require 'i18n_country_translations/railtie'
 
 module I18nCountryTranslations

--- a/lib/i18n_country_translations/locale_files_pattern_generator.rb
+++ b/lib/i18n_country_translations/locale_files_pattern_generator.rb
@@ -1,0 +1,32 @@
+module I18nCountryTranslations
+
+  # Generates patterns for locale files, bases on a list of supported locales
+  class LocaleFilesPatternGenerator
+
+    attr_reader :base_pattern, :extension
+
+    def initialize(base_pattern, extension = '.yml')
+      @base_pattern = base_pattern
+      @extension = extension
+    end
+
+    # Generates a glob file pattern for the specified list of locales (i.e. IETF language tags)
+    def pattern_from(locales)
+      locales = Array(locales || [])
+      locales = locales.map { |locale| subpatterns_from locale }.flatten
+      pattern = locales.blank? ? '*' : "{#{locales.join ','}}"
+      "#{base_pattern}#{pattern}#{extension}"
+    end
+
+    protected
+
+    # Generates subpatterns for the specified locale (i.e. IETF language tag).
+    # Subpatterns are all more generic variations of a locale.
+    # E.g. subpatterns for en-US are en-US and en. Subpatterns for az-Latn-IR are az-Latn-IR, az-Latn and az
+    def subpatterns_from(locale)
+      parts = locale.to_s.split('-')
+      parts.map.with_index { |part,index| parts[0..index].join('-') }
+    end
+
+  end
+end

--- a/lib/i18n_country_translations/railtie.rb
+++ b/lib/i18n_country_translations/railtie.rb
@@ -19,7 +19,13 @@ module I18nCountryTranslations
 
     def self.pattern_from(args)
       array = Array(args || [])
+      array = array.map { |locale| subpatterns_from locale }.flatten
       array.blank? ? '*' : "{#{array.join ','}}"
+    end
+
+    def self.subpatterns_from(locale)
+      parts = locale.to_s.split('-')
+      parts.map.with_index { |part,index| parts[0..index].join('-') }
     end
   end
 end

--- a/lib/i18n_country_translations/railtie.rb
+++ b/lib/i18n_country_translations/railtie.rb
@@ -4,9 +4,8 @@ module I18nCountryTranslations
   class Railtie < ::Rails::Railtie #:nodoc:
     initializer 'i18n-country-translations' do |app|
       I18nCountryTranslations::Railtie.instance_eval do
-        pattern = pattern_from app.config.i18n.available_locales
-
-        add("rails/locale/**/#{pattern}.yml")
+        generator = LocaleFilesPatternGenerator.new('rails/locale/**/')
+        add generator.pattern_from app.config.i18n.available_locales
       end
     end
 
@@ -17,15 +16,5 @@ module I18nCountryTranslations
       I18n.load_path.concat(files)
     end
 
-    def self.pattern_from(args)
-      array = Array(args || [])
-      array = array.map { |locale| subpatterns_from locale }.flatten
-      array.blank? ? '*' : "{#{array.join ','}}"
-    end
-
-    def self.subpatterns_from(locale)
-      parts = locale.to_s.split('-')
-      parts.map.with_index { |part,index| parts[0..index].join('-') }
-    end
   end
 end

--- a/spec/lib/i18n_country_translations/locale_files_pattern_generator_spec.rb
+++ b/spec/lib/i18n_country_translations/locale_files_pattern_generator_spec.rb
@@ -5,18 +5,40 @@ describe I18nCountryTranslations::LocaleFilesPatternGenerator do
   context "with given locale" do
     let(:generator) { I18nCountryTranslations::LocaleFilesPatternGenerator.new('base/', '.yml') }
 
+    def test_pattern(pattern, sample)
+      if defined? File::FNM_EXTGLOB
+        # Use proper way to test, by calling fnmatch and actually executing the pattern.
+        # This only works in Ruby 2.1.0 and upwards
+        File.fnmatch(pattern, sample, File::FNM_EXTGLOB)
+      else
+        # Roughly approximate pattern matching using regular expressions. Only recognizes the braces { } syntax.
+        # Other glob syntax (e.g. * and ** is not recognized). So keep test cases simple!
+        pattern = '^' + pattern.split(/\{(.+?)\}/).each_with_index.map do |part, index|
+          if index.even?
+            # Pattern part outside of { }
+            Regexp.escape(part)
+          else
+            '(' + part.split(',').map { |option| Regexp.escape(option) }.join('|') + ')'
+          end
+        end.join + '$'
+
+        # Test against regular expression pattern
+        (sample =~ Regexp.new(pattern)) == 0
+      end
+    end
+
     it "generates a pattern for simple locales" do
       locales = ['en', 'fr']
       pattern = generator.pattern_from(locales)
 
       # Make sure pattern matches locales
       locales.each do |locale|
-        expect(File.fnmatch(pattern, "base/#{locale}.yml", File::FNM_EXTGLOB)).to be true
+        expect(test_pattern(pattern, "base/#{locale}.yml")).to be true
       end
 
       # Make sure pattern does not match other locales
       ['nl', 'en-US', 'fra', 'cen'].each do |locale|
-        expect(File.fnmatch(pattern, "base/#{locale}.yml", File::FNM_EXTGLOB)).to be false
+        expect(test_pattern(pattern, "base/#{locale}.yml")).to be false
       end
     end
 
@@ -27,12 +49,12 @@ describe I18nCountryTranslations::LocaleFilesPatternGenerator do
 
       # Make sure pattern matches locales
       sublocales.each do |locale|
-        expect(File.fnmatch(pattern, "base/#{locale}.yml", File::FNM_EXTGLOB)).to be true
+        expect(test_pattern(pattern, "base/#{locale}.yml")).to be true
       end
 
       # Make sure pattern does not match other locales
       ['en-AU', 'az-IR'].each do |locale|
-        expect(File.fnmatch(pattern, "base/#{locale}.yml", File::FNM_EXTGLOB)).to be false
+        expect(test_pattern(pattern, "base/#{locale}.yml")).to be false
       end
     end
   end

--- a/spec/lib/i18n_country_translations/locale_files_pattern_generator_spec.rb
+++ b/spec/lib/i18n_country_translations/locale_files_pattern_generator_spec.rb
@@ -6,7 +6,7 @@ describe I18nCountryTranslations::LocaleFilesPatternGenerator do
     let(:generator) { I18nCountryTranslations::LocaleFilesPatternGenerator.new('base/', '.yml') }
 
     def test_pattern(pattern, sample)
-      if defined? File::FNM_EXTGLOB
+      if File.const_defined? 'FNM_EXTGLOB'
         # Use proper way to test, by calling fnmatch and actually executing the pattern.
         # This only works in Ruby 2.1.0 and upwards
         File.fnmatch(pattern, sample, File::FNM_EXTGLOB)

--- a/spec/lib/i18n_country_translations/locale_files_pattern_generator_spec.rb
+++ b/spec/lib/i18n_country_translations/locale_files_pattern_generator_spec.rb
@@ -1,0 +1,40 @@
+require 'i18n_country_translations/locale_files_pattern_generator'
+
+describe I18nCountryTranslations::LocaleFilesPatternGenerator do
+
+  context "with given locale" do
+    let(:generator) { I18nCountryTranslations::LocaleFilesPatternGenerator.new('base/', '.yml') }
+
+    it "generates a pattern for simple locales" do
+      locales = ['en', 'fr']
+      pattern = generator.pattern_from(locales)
+
+      # Make sure pattern matches locales
+      locales.each do |locale|
+        expect(File.fnmatch(pattern, "base/#{locale}.yml", File::FNM_EXTGLOB)).to be true
+      end
+
+      # Make sure pattern does not match other locales
+      ['nl', 'en-US', 'fra', 'cen'].each do |locale|
+        expect(File.fnmatch(pattern, "base/#{locale}.yml", File::FNM_EXTGLOB)).to be false
+      end
+    end
+
+    it "generates a pattern for locales with tags" do
+      locales = ['en-US', 'az-Latn-IR']
+      sublocales = ['en', 'en-US', 'az', 'az-Latn', 'az-Latn-IR']
+      pattern = generator.pattern_from(locales)
+
+      # Make sure pattern matches locales
+      sublocales.each do |locale|
+        expect(File.fnmatch(pattern, "base/#{locale}.yml", File::FNM_EXTGLOB)).to be true
+      end
+
+      # Make sure pattern does not match other locales
+      ['en-AU', 'az-IR'].each do |locale|
+        expect(File.fnmatch(pattern, "base/#{locale}.yml", File::FNM_EXTGLOB)).to be false
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
I18n fallbacks don't quite work when a fallback is not specified as an available locale, but translations for the fallback are available. This would cause problems, for example in the following case: `zh-CN` is specified as an available language, but `zh` is not. This may be a legitimate situation. Falling back to `zh` is still desirable. Because `i18n-country-translations` does not contain explicit translations for `zh-CN`, not including `zh` as an available locale would cause I18n to fallback to `en`, which is of course not desirable.

My patch forces loading of fallbacks in a simple way, by adding all fallbacks for a locale to the list of locale files to be loaded.