### PR TITLE
Make changelog parseable by vandamme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+## Unreleased
+
+- Split out changelog
+
+## 1.2.2
+
+- Add Traditional Chinese support
+
+## 1.2.1
+
+- Update glob to include locales again. Fix import task
+
+## 1.1.1
+
+- Fixing bug from incorrect translation paths. Update gemspec for Rails 4 support.
+
+## 1.1.0
+
+- Updating all locales and separating out iso639-1 locales from 3 character unicode supported locales
+
+## 1.0.4
+
+- Adding zh-HK and zh-CN translations.
+
+## 1.0.3
+
+- Adding zh-TW translations.
+
+## 1.0.2
+
+- Fixing bad PT translations. Adding licenses to gemspec.
+
+## 1.0.1
+
+- Fixing bad version in Gemfile.lock
+
+## 1.0.0
+
+- Adding fr-CA translation
+
+## 0.0.9
+
+- Update the locale files with the last values from the CLDR repository

--- a/README.rdoc
+++ b/README.rdoc
@@ -22,9 +22,9 @@ Add to your Gemfile:
 == Usage
 
   I18n.t(:US, :scope => :countries)
-  
+
 or
-  
+
   t(:US, :scope => :countries)
 
 == Contributing
@@ -62,18 +62,6 @@ https://github.com/onomojo/i18n_country_select
 
 If you need to use timezones, we also created a convenient way to translate the default Rails timezones with the gem i18n-timezones
 https://github.com/onomojo/i18n-timezones
-
-== Version History
-* 1.2.2 - Add Traditional Chinese support
-* 1.2.1 - Update glob to include locales again. Fix import task
-* 1.1.1 - Fixing bug from incorrect translation paths. Update gemspec for Rails 4 support.
-* 1.1.0 - Updating all locales and separating out iso639-1 locales from 3 character unicode supported locales
-* 1.0.4 - Adding zh-HK and zh-CN translations.
-* 1.0.3 - Adding zh-TW translations.
-* 1.0.2 - Fixing bad PT translations. Adding licenses to gemspec.
-* 1.0.1 - Fixing bad version in Gemfile.lock
-* 1.0 - Adding fr-CA translation
-* 0.0.9 - Update the locale files with the last values from the CLDR repository
 
 == License
 MIT or GPL


### PR DESCRIPTION
How would you feel about splitting out the changelog for this project so that it's parseable by [vandamme](https://github.com/tech-angels/vandamme/)? Would be awesome to be able to see changes at a glance from within services like Gemnasium.