### PR TITLE
Fix country translations lost on reload in development (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.2
+
+- Fix country translations disappearing in development after editing any file in `config/locales/` (issue #91). Editing a locale file triggers `I18n.reload!`, which clears the in-memory backend and rebuilds it only from `I18n.load_path`; translations injected via `store_translations` were wiped until the next server restart. They are now re-loaded after every reload via the reloader's `to_prepare` hook.
+
 ## 2.3.1
 
 - Fix `I18n.t(:XX, scope: :countries)` returning "translation missing" when `config.i18n.available_locales` is set as an Array of Strings (issue #89). The locale filter in `Railtie.load_translations` now normalizes to symbols before comparison.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    i18n-country-translations (2.3.1)
+    i18n-country-translations (2.3.2)
       i18n (>= 0.9.3, < 3)
       i18n-country-translations-data (~> 1.1)
       railties (>= 7.2, < 9)

--- a/lib/i18n_country_translations/railtie.rb
+++ b/lib/i18n_country_translations/railtie.rb
@@ -12,6 +12,17 @@ module I18nCountryTranslations
       )
     end
 
+    # Re-store translations after every reload. I18n.reload! (triggered in
+    # development by editing config/locales files) clears the backend and
+    # rebuilds it only from I18n.load_path, dropping our store_translations data.
+    initializer "i18n_country_translations.reload" do |app|
+      app.reloader.to_prepare do
+        I18nCountryTranslations::Railtie.load_translations(
+          app.config.i18n.available_locales
+        )
+      end
+    end
+
     def self.load_translations(locales = nil)
       data_dir = I18nCountryTranslationsData.data_dir
       locales = locales.map(&:to_sym) if locales.present?

--- a/lib/i18n_country_translations/version.rb
+++ b/lib/i18n_country_translations/version.rb
@@ -1,3 +1,3 @@
 module I18nCountryTranslations
-  VERSION = "2.3.1"
+  VERSION = "2.3.2"
 end

--- a/spec/unit/reload_spec.rb
+++ b/spec/unit/reload_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "surviving an I18n reload" do
+  it "keeps country translations after a development reload cycle" do
+    expect(I18n.t(:FR, scope: :countries, locale: :fr)).to eql "France"
+
+    I18n.reload!
+    Rails.application.reloader.prepare!
+
+    expect(I18n.t(:FR, scope: :countries, locale: :fr)).to eql "France"
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #91 — country translations disappear in development after editing any file in `config/locales/` (`Translation missing: fr.countries.FR`), until the server is restarted.

## Root cause

A regression introduced in the 2.2.0/2.3.0 rewrite. The gem changed how it registers translations with I18n:

- **2.1.0 (worked):** `I18n.load_path.concat(files)` — files on the load path.
- **2.3.x (broke):** `I18n.backend.store_translations(...)` — injected directly into the in-memory backend.

In development, editing a locale file makes Rails fire `I18n.reload!`, which **clears the entire backend and rebuilds it only from `I18n.load_path`**. Because the country data was injected via `store_translations` (not on the load path), the reload wiped it with no way to restore it short of a restart. This matches every symptom in the issue: boots fine, breaks on the first locale-file edit, restart fixes it, and ≤ 2.1.0 is unaffected.

## Fix

Kept entirely within this gem (no change to the shared `i18n-country-translations-data` gem): preserve the existing `after_initialize` boot load, and register `app.reloader.to_prepare` from an initializer to re-inject the translations after every reload.

## Testing

- Added `spec/unit/reload_spec.rb`, a regression test simulating a dev file-edit (`I18n.reload!` + `reloader.prepare!`). It fails with the issue's exact error before the fix and passes after.
- Full suite: **174 examples, 0 failures**, 100% line coverage.

Bumped to **2.3.2** (patch) with a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)